### PR TITLE
Show VCS change markers in the gutter of the decrypted editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Show VCS change markers in the gutter of the decrypted editor, comparing the decrypted content with the
+  decrypted content of the last commit.
+
 ### Fixed
 
 - Decrypt the content of the last commit with the store of the file it comes from, instead of always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Decrypt the content of the last commit with the store of the file it comes from, instead of always
+  decrypting it as YAML.
+
 ## [1.4.1] - 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ SOPS IntelliJ plugin allows you to decrypt and encrypt files encrypted with SOPS
 - Automatically decrypt the content of SOPS files.
 - Show encrypted content as preview.
 - On save, encrypt the contents, if the file has changed.
+- Show VCS change markers for the decrypted content in the gutter of the editor.
 
 ## Demo
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = org.jetbrains.kotlin
 # Example: platformBundledModules = intellij.spellchecker
-platformBundledModules =
+platformBundledModules = intellij.platform.vcs.impl
 
 # Java language level used to compile sources and to generate the files for
 # - Java 11 is required since 2020.3

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/SopsWrapper.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/SopsWrapper.kt
@@ -54,13 +54,18 @@ object SopsWrapper {
         run("decrypt", project, file, inPlace, onSuccess, onError)
     }
 
+    /**
+     * SOPS determines the input format from the file extension, so [extension] should be the extension
+     * of the file the text comes from, when it is known.
+     */
     suspend fun decrypt(
         text: String,
         project: Project,
+        extension: String? = null,
         onSuccess: suspend (String) -> Unit,
         onError: suspend (String) -> Unit = {}
     ) {
-        val tmpFilePath = Files.createTempFile("sopsIntellijPlugin", ".yaml")
+        val tmpFilePath = Files.createTempFile("sopsIntellijPlugin", ".${extension ?: "yaml"}")
         Files.writeString(tmpFilePath, text)
         // Delete on JVM exit
         val tmpFile = tmpFilePath.toFile()

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/providers/SopsEditorProvider.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/providers/SopsEditorProvider.kt
@@ -73,7 +73,7 @@ class SopsEditorProvider : FileEditorProvider, DumbAware {
                     }
                     // Content might not be encrypted, so decryption might fail
                     // But since this content might be outdated, we do not want to show an error
-                    project.service<SopsService>().decrypt(originalEncryptedText, { decryptedText ->
+                    project.service<SopsService>().decrypt(originalEncryptedText, file.extension, { decryptedText ->
                         originalDecryptedText = decryptedText
                     })
                 }

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/providers/SopsEditorProvider.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/providers/SopsEditorProvider.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vcs.ex.SimpleLocalLineStatusTracker
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import com.intellij.testFramework.LightVirtualFile
@@ -53,6 +54,15 @@ class SopsEditorProvider : FileEditorProvider, DumbAware {
         var originalEncryptedText = (previewEditor as TextEditor).editor.document.text
         var originalDecryptedText: String? = null
 
+        /**
+         * Shows the difference between the decrypted content and the decrypted content of the last commit
+         * in the gutter of the decrypted editor. The decrypted editor is backed by a [LightVirtualFile],
+         * which is not under version control, so the platform does not track it on its own.
+         */
+        private var lineStatusTracker: SimpleLocalLineStatusTracker? = null
+        private var isDecryptedTextLoaded = false
+        private var isBaseRevisionLoading = false
+
         init {
             (editor as? Disposable)?.let { Disposer.register(this, it) }
             (previewEditor as? Disposable)?.let { Disposer.register(this, it) }
@@ -66,18 +76,7 @@ class SopsEditorProvider : FileEditorProvider, DumbAware {
                 }
             })
 
-            editor.project?.let { project ->
-                project.service<SopsVcsService>().getLastCommitContent(file) { content ->
-                    if (content != null) {
-                        originalEncryptedText = content
-                    }
-                    // Content might not be encrypted, so decryption might fail
-                    // But since this content might be outdated, we do not want to show an error
-                    project.service<SopsService>().decrypt(originalEncryptedText, file.extension, { decryptedText ->
-                        originalDecryptedText = decryptedText
-                    })
-                }
-            }
+            loadBaseRevision(isInitialLoad = true)
 
             // This will show an error if the current content is not valid
             decrypt()
@@ -90,12 +89,81 @@ class SopsEditorProvider : FileEditorProvider, DumbAware {
                         WriteAction.run<Throwable> {
                             editor.document.setText(decryptedContent)
                         }
+                        isDecryptedTextLoaded = true
+                        updateLineStatusTracker()
                     }
                 })
             }
         }
 
+        override fun selectNotify() {
+            super.selectNotify()
+            // The last commit changes when the file is committed, checked out or updated,
+            // which leaves the gutter of the decrypted editor showing an outdated difference.
+            loadBaseRevision(isInitialLoad = false)
+        }
+
+        /**
+         * Decrypts the content of the last commit, which is both the base revision of the gutter markers
+         * and how [SopsService.editEncrypt] recognizes that the content has not changed.
+         */
+        private fun loadBaseRevision(isInitialLoad: Boolean) {
+            val project = editor.project ?: return
+            if (isBaseRevisionLoading) {
+                return
+            }
+            isBaseRevisionLoading = true
+
+            project.service<SopsVcsService>().getLastCommitContent(file) { content ->
+                if (!isInitialLoad && (content == null || content == originalEncryptedText)) {
+                    isBaseRevisionLoading = false
+                    return@getLastCommitContent
+                }
+
+                if (content != null) {
+                    originalEncryptedText = content
+                }
+                // Content might not be encrypted, so decryption might fail
+                // But since this content might be outdated, we do not want to show an error
+                project.service<SopsService>().decrypt(
+                    originalEncryptedText,
+                    // SOPS picks the store from the file extension, so decrypting the content of the last
+                    // commit as anything else returns it in another format, which the gutter would then
+                    // show as a difference. A binary store file, for example, comes back wrapped in YAML.
+                    file.extension,
+                    { decryptedText ->
+                        originalDecryptedText = decryptedText
+                        isBaseRevisionLoading = false
+                        updateLineStatusTracker()
+                    },
+                    {
+                        isBaseRevisionLoading = false
+                    }
+                )
+            }
+        }
+
+        private suspend fun updateLineStatusTracker() {
+            val project = editor.project ?: return
+            val baseDecryptedText = originalDecryptedText ?: return
+            // Setting the base revision before the editor shows the decrypted content
+            // would mark the whole file as changed
+            if (!isDecryptedTextLoaded) {
+                return
+            }
+
+            withContext(Dispatchers.EDT) {
+                val decryptedFile = FileDocumentManager.getInstance().getFile(editor.document) ?: return@withContext
+                val tracker = lineStatusTracker
+                    ?: SimpleLocalLineStatusTracker.createTracker(project, editor.document, decryptedFile)
+                        .also { lineStatusTracker = it }
+
+                tracker.setBaseRevision(baseDecryptedText)
+            }
+        }
+
         override fun dispose() {
+            lineStatusTracker?.release()
             EditorFactory.getInstance().releaseEditor(editor)
             EditorFactory.getInstance().releaseEditor((previewEditor as TextEditor).editor)
         }

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/services/SopsService.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/services/SopsService.kt
@@ -56,16 +56,17 @@ class SopsService(
 
     fun decrypt(
         text: String,
+        extension: String? = null,
         onSuccess: suspend (decryptedText: String) -> Unit,
         onError: suspend (message: String?) -> Unit = {}
     ) {
         cs.launch {
             withBackgroundProgress(project, message("background.decrypting")) {
                 AppSettings.instance.recordHit()
-                SopsWrapper.decrypt(text, project, {
+                SopsWrapper.decrypt(text, project, extension, onSuccess = {
                     AppSettings.instance.recordHit()
                     onSuccess(it)
-                }, onError)
+                }, onError = onError)
             }
         }
     }
@@ -84,7 +85,7 @@ class SopsService(
 
                 val originalEncryptedText = file.getLastCommitContent(project)
                 var originalDecryptedText = ""
-                SopsWrapper.decrypt(originalEncryptedText.orEmpty(), project, onSuccess = {
+                SopsWrapper.decrypt(originalEncryptedText.orEmpty(), project, file.extension, onSuccess = {
                     originalDecryptedText = it
                 })
 


### PR DESCRIPTION
Closes #90.

The decrypted editor is backed by a `LightVirtualFile`, which is not under version control, so the platform never creates a line status tracker for it. The gutter stays empty, and the difference is only visible in the preview, as encrypted text.

The plugin already fetches and decrypts the content of the last commit, to decide whether a file has really changed before re-encrypting it. That decrypted content is exactly the base revision the gutter needs, so it is now also handed to a `SimpleLocalLineStatusTracker` installed on the decrypted document. The tracker's renderer writes into the document markup model, so the decrypted editor picks the markers up with no changes to the editor itself, and the chunk popup with **Show Diff** and **Rollback** comes along for free.

Two details worth pointing out for review:

* The base revision is only applied once the decrypted content is in the document. Applying it earlier marks the whole file as changed on the first paint.
* `selectNotify` reloads the base revision, so the markers stop comparing against a commit that is no longer the last one after a commit, checkout or update. It skips the decryption when the content of the last commit has not changed, so selecting a tab does not run SOPS every time.

### The first commit is a fix, not part of the feature

`SopsWrapper.decrypt(text, …)` wrote the content of the last commit to a temporary `.yaml` file, and SOPS picks its store from the file extension. For a file that is not YAML the content came back in a different format — a binary store file, such as an encrypted dotenv, comes back as a YAML block scalar:

```
decrypt as .binary (what the editor shows)   decrypt as .yaml (what the plugin compared against)
FIRST=one                                    data: |
SECOND=two                                       FIRST=one
THIRD=three                                      SECOND=two
                                                 THIRD=three
```

Without this the new gutter markers report every line of such a file as changed. It also affects `main` today, independently of this PR: both places that decrypt the content of the last commit compare it with the decrypted file to avoid rewriting an unchanged file, and that comparison could never succeed for those files, so the MAC and `lastmodified` were rewritten even when nothing had changed. Passing the extension of the file the content comes from puts both sides of the comparison through the same store.

### Note on `platformBundledModules`

`SimpleLocalLineStatusTracker` lives in `intellij.platform.vcs.impl`. On 2024.2 its classes are reachable without declaring anything, but on 2026.2 that module is a separate jar and is not on the compile classpath, so the build fails with an unresolved reference. Declaring the bundled module works on both — I compiled against IC 2024.2, as configured in the repository, and against a local 2026.2 install.

### Testing

Tested in IntelliJ IDEA 2026.2 with binary store SOPS files (encrypted dotenv) and YAML store files: clean gutter on an unmodified committed file, markers on the edited lines only, and markers clearing after a commit. I have not added tests, since the change is in a `FileEditor` and there is no test setup in the repository yet — happy to add some if you would like to point me at how you would want them written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)