### PR TITLE
Show the decrypted difference in the comparison window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Show VCS change markers in the gutter of the decrypted editor, comparing the decrypted content with the
   decrypted content of the last commit.
+- Compare the decrypted contents of the files that are being compared, switching between the decrypted
+  and the encrypted contents from the toolbar of the comparison window. The setting `Decrypt contents
+  in the comparison window` decides which of the two a window starts with.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ SOPS IntelliJ plugin allows you to decrypt and encrypt files encrypted with SOPS
 - Show encrypted content as preview.
 - On save, encrypt the contents, if the file has changed.
 - Show VCS change markers for the decrypted content in the gutter of the editor.
+- Compare the decrypted contents of SOPS files in the comparison window, switching between the
+  decrypted and the encrypted contents from its toolbar.
 
 ## Demo
 

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/SopsUtil.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/SopsUtil.kt
@@ -3,10 +3,13 @@ package com.github.blarc.sops.intellij.plugin
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.readAction
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.impl.LoadTextUtil
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.vcs.ProjectLevelVcsManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFileFactory
@@ -23,13 +26,34 @@ object SopsUtil {
         "version"
     )
 
+    private val SOPS_DOCUMENT_KEY = Key.create<Pair<Long, Boolean>>("sops.isSopsDocument")
+
     fun isSopsFileBasedOnContent(file: VirtualFile): Boolean {
         try {
             val content: String = ReadAction.compute<String, RuntimeException> { LoadTextUtil.loadText(file).toString() }
-            return SOPS_KEYWORDS.stream().allMatch { s: String -> content.contains(s) }
+            return isSopsContent(content)
         } catch (e: Exception) {
             thisLogger().warn("could not get content of file ${file.name} $e")
         }
         return false
+    }
+
+    fun isSopsContent(content: String): Boolean {
+        return SOPS_KEYWORDS.all { content.contains(it) }
+    }
+
+    /**
+     * Actions are updated often, so the result is cached until the document is modified,
+     * to avoid scanning the whole content on every update.
+     */
+    fun isSopsDocument(document: Document): Boolean {
+        val cached = document.getUserData(SOPS_DOCUMENT_KEY)
+        if (cached != null && cached.first == document.modificationStamp) {
+            return cached.second
+        }
+
+        val isSopsDocument = isSopsContent(runReadAction { document.text })
+        document.putUserData(SOPS_DOCUMENT_KEY, document.modificationStamp to isSopsDocument)
+        return isSopsDocument
     }
 }

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/diff/SopsDiffContents.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/diff/SopsDiffContents.kt
@@ -1,0 +1,80 @@
+package com.github.blarc.sops.intellij.plugin.diff
+
+import com.github.blarc.sops.intellij.plugin.SopsUtil.isSopsDocument
+import com.intellij.diff.DiffContentFactory
+import com.intellij.diff.contents.DocumentContent
+import com.intellij.diff.requests.ContentDiffRequest
+import com.intellij.diff.requests.DiffRequest
+import com.intellij.diff.requests.SimpleDiffRequest
+import com.intellij.diff.util.DiffUserDataKeys
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.project.Project
+import java.util.Collections
+
+/**
+ * The decrypted contents of the documents that are being compared.
+ *
+ * Decrypting runs SOPS, so the result is remembered. A comparison window asks for it more than once:
+ * when the window is created, when it is reloaded after the decryption has finished and whenever the
+ * same contents are compared again. The results are remembered by the encrypted content they come
+ * from, because a window that is reloaded compares the same content in new documents.
+ */
+object SopsDiffContents {
+
+    private const val MAX_REMEMBERED_CONTENTS = 16
+
+    /**
+     * The decrypted content of an encrypted content. Only the last few are kept, so that the contents
+     * of windows that have been closed do not stay in memory.
+     */
+    private val decryptedContents: MutableMap<String, String> = Collections.synchronizedMap(
+        object : LinkedHashMap<String, String>(MAX_REMEMBERED_CONTENTS, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<String, String>) = size > MAX_REMEMBERED_CONTENTS
+        }
+    )
+
+    /**
+     * The contents of [request] that are encrypted with SOPS. Only documents can be looked at, so a
+     * content of another kind, a directory for example, is never considered encrypted.
+     */
+    fun encryptedContents(request: DiffRequest): List<DocumentContent> {
+        if (request !is ContentDiffRequest) return emptyList()
+        return request.contents.filterIsInstance<DocumentContent>().filter { isSopsDocument(it.document) }
+    }
+
+    /** Every content of [request] that is encrypted with SOPS has been decrypted. */
+    fun isDecrypted(request: DiffRequest) = encryptedContents(request).all { isDecrypted(it.encryptedText()) }
+
+    fun isDecrypted(encryptedText: String) = decryptedContents.containsKey(encryptedText)
+
+    fun remember(encryptedText: String, decryptedText: String) {
+        decryptedContents[encryptedText] = decryptedText
+    }
+
+    /**
+     * The [request] with every content that is encrypted with SOPS replaced by its decrypted content.
+     * Contents that are not encrypted are shown as they are, so an encrypted file can also be
+     * compared with a plain one.
+     */
+    fun decryptedRequest(project: Project, request: ContentDiffRequest): SimpleDiffRequest {
+        val contentFactory = DiffContentFactory.getInstance()
+        val contents = request.contents.map { content ->
+            val decryptedText = (content as? DocumentContent)?.let { decryptedContents[it.encryptedText()] }
+                ?: return@map content
+            contentFactory.create(project, decryptedText, content.contentType)
+        }
+
+        val decryptedRequest = SimpleDiffRequest(
+            request.title,
+            contents,
+            request.contentTitles.map { it.orEmpty() }
+        )
+
+        // The decrypted contents are not backed by the files that are being compared, so changes to
+        // them would be lost. They are shown read only, instead of pretending that they can be edited.
+        decryptedRequest.putUserData(DiffUserDataKeys.FORCE_READ_ONLY, true)
+        return decryptedRequest
+    }
+
+    private fun DocumentContent.encryptedText(): String = runReadAction { document.text }
+}

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/diff/SopsDiffTool.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/diff/SopsDiffTool.kt
@@ -1,0 +1,176 @@
+package com.github.blarc.sops.intellij.plugin.diff
+
+import com.github.blarc.sops.intellij.plugin.Icons
+import com.github.blarc.sops.intellij.plugin.SopsBundle.message
+import com.github.blarc.sops.intellij.plugin.services.SopsService
+import com.github.blarc.sops.intellij.plugin.settings.AppSettings
+import com.intellij.diff.DiffContext
+import com.intellij.diff.DiffContextEx
+import com.intellij.diff.DiffTool
+import com.intellij.diff.DiffToolType
+import com.intellij.diff.FrameDiffTool
+import com.intellij.diff.SuppressiveDiffTool
+import com.intellij.diff.requests.ContentDiffRequest
+import com.intellij.diff.requests.DiffRequest
+import com.intellij.diff.tools.ErrorDiffTool
+import com.intellij.diff.tools.fragmented.UnifiedDiffTool
+import com.intellij.diff.tools.simple.SimpleDiffTool
+import com.intellij.diff.util.DiffUtil
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.swing.JComponent
+
+/** Whether a comparison window shows the decrypted contents instead of the encrypted ones. */
+private val SHOW_DECRYPTED = Key.create<Boolean>("sops.diff.showDecrypted")
+
+/**
+ * A window that has not been switched shows what the setting asks for, so that the same window can be
+ * switched back and forth without changing what every other window shows.
+ */
+private fun DiffContext.isShowingDecrypted(): Boolean =
+    getUserData(SHOW_DECRYPTED) ?: AppSettings.instance.sopsDecryptDiff
+
+/**
+ * Shows the decrypted contents of the files that are being compared with [delegate], so that SOPS
+ * files can be compared without decrypting them first. It takes the place of [delegate] whenever the
+ * compared contents are encrypted with SOPS, and shows them with [delegate] itself, which keeps
+ * everything that viewer can do.
+ *
+ * Decrypting runs SOPS, which cannot be waited for while the window is being created. The window shows
+ * that it is decrypting and is reloaded once the decrypted contents are known, which is when they are
+ * handed over to [delegate]. The action that switches between the encrypted and the decrypted contents
+ * is added to the toolbar of the window, and switches them in the same window.
+ */
+abstract class SopsDiffTool(private val delegate: FrameDiffTool) : FrameDiffTool, SuppressiveDiffTool {
+
+    /** The window offers this viewer under the name of the viewer it takes the place of. */
+    override fun getName(): String = delegate.name
+
+    /** The window shows the icon of the viewer it takes the place of as well. */
+    override fun getToolType(): DiffToolType = delegate.toolType
+
+    /** Only one of the two is offered by the window, because they show the same contents. */
+    override fun getSuppressedTools(): List<Class<out DiffTool>> = listOf(delegate.javaClass)
+
+    override fun canShow(context: DiffContext, request: DiffRequest): Boolean {
+        // The window has to be reloadable, because the contents are decrypted in the background and
+        // because the action switches between the decrypted and the encrypted contents.
+        if (context !is DiffContextEx || context.project == null) return false
+        if (request !is ContentDiffRequest) return false
+        if (SopsDiffContents.encryptedContents(request).isEmpty()) return false
+        return delegate.canShow(context, request)
+    }
+
+    override fun createComponent(context: DiffContext, request: DiffRequest): FrameDiffTool.DiffViewer {
+        val project = context.project
+        if (project == null || context !is DiffContextEx || request !is ContentDiffRequest) {
+            return ErrorDiffTool.INSTANCE.createComponent(context, request)
+        }
+
+        if (!context.isShowingDecrypted()) {
+            return SopsDiffViewer(delegate.createComponent(context, request), context)
+        }
+
+        if (!SopsDiffContents.isDecrypted(request)) {
+            return SopsDecryptingDiffViewer(project, context, request)
+        }
+
+        val decryptedRequest = SopsDiffContents.decryptedRequest(project, request)
+        return SopsDiffViewer(delegate.createComponent(context, decryptedRequest), context)
+    }
+}
+
+/** Shows the decrypted contents next to each other. */
+class SopsSideBySideDiffTool : SopsDiffTool(SimpleDiffTool.INSTANCE)
+
+/** Shows the decrypted contents in a single editor. */
+class SopsUnifiedDiffTool : SopsDiffTool(UnifiedDiffTool.INSTANCE)
+
+/**
+ * Shows that the contents are being decrypted and reloads the comparison window once they are, which
+ * is when the decrypted contents are shown.
+ */
+private class SopsDecryptingDiffViewer(
+    private val project: Project,
+    private val context: DiffContextEx,
+    private val request: ContentDiffRequest,
+) : FrameDiffTool.DiffViewer {
+
+    private val panel = DiffUtil.createMessagePanel(message("diff.decrypting"))
+    private var isDisposed = false
+
+    override fun getComponent(): JComponent = panel
+
+    override fun getPreferredFocusedComponent(): JComponent? = null
+
+    override fun init(): FrameDiffTool.ToolbarComponents {
+        context.showProgressBar(true)
+        project.service<SopsService>().decryptDiffContents(request) { isDecrypted ->
+            withContext(Dispatchers.EDT) {
+                if (isDisposed) return@withContext
+                context.showProgressBar(false)
+                // Contents that could not be decrypted are shown as they are, so that the toolbar
+                // shows what the window shows and decrypting is not tried over and over again.
+                if (!isDecrypted) {
+                    context.putUserData(SHOW_DECRYPTED, false)
+                }
+                // The decrypted contents are remembered, so the reloaded window shows them without
+                // decrypting them again.
+                context.reloadDiffRequest()
+            }
+        }
+
+        val components = FrameDiffTool.ToolbarComponents()
+        components.toolbarActions = listOf(SopsShowDecryptedAction(context))
+        return components
+    }
+
+    override fun dispose() {
+        isDisposed = true
+    }
+}
+
+/**
+ * The viewer that shows the contents, with the action that switches between the decrypted and the
+ * encrypted contents added to the toolbar of the comparison window.
+ */
+private class SopsDiffViewer(
+    private val delegate: FrameDiffTool.DiffViewer,
+    private val context: DiffContextEx,
+) : FrameDiffTool.DiffViewer by delegate {
+
+    override fun init(): FrameDiffTool.ToolbarComponents {
+        val components = delegate.init()
+        components.toolbarActions = components.toolbarActions.orEmpty() + SopsShowDecryptedAction(context)
+        return components
+    }
+}
+
+/**
+ * Switches the comparison window between the encrypted and the decrypted contents. It is pressed while
+ * the decrypted contents are shown, so that a window that shows the contents as they are on disk looks
+ * like any other comparison window.
+ */
+private class SopsShowDecryptedAction(private val context: DiffContextEx) : ToggleAction(
+    message("diff.action.show-decrypted"),
+    null,
+    Icons.KEY_ICON.getThemeBasedIcon()
+), DumbAware {
+
+    override fun isSelected(e: AnActionEvent) = context.isShowingDecrypted()
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        context.putUserData(SHOW_DECRYPTED, state)
+        context.reloadDiffRequest()
+    }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
+}

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/services/SopsService.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/services/SopsService.kt
@@ -2,9 +2,13 @@ package com.github.blarc.sops.intellij.plugin.services
 
 import com.github.blarc.sops.intellij.plugin.SopsBundle.message
 import com.github.blarc.sops.intellij.plugin.SopsWrapper
+import com.github.blarc.sops.intellij.plugin.diff.SopsDiffContents
 import com.github.blarc.sops.intellij.plugin.equalsIgnoreIndent
 import com.github.blarc.sops.intellij.plugin.getLastCommitContent
+import com.github.blarc.sops.intellij.plugin.notifications.Notification
+import com.github.blarc.sops.intellij.plugin.notifications.sendNotification
 import com.github.blarc.sops.intellij.plugin.settings.AppSettings
+import com.intellij.diff.requests.ContentDiffRequest
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.runWriteAction
@@ -68,6 +72,51 @@ class SopsService(
                     AppSettings.instance.recordHit()
                     onSuccess(it)
                 }, onError = onError)
+            }
+        }
+    }
+
+    /**
+     * Decrypts the contents of [request] that are encrypted with SOPS, remembering them in
+     * [SopsDiffContents], and then runs [onFinished] with whether all of them could be decrypted.
+     */
+    fun decryptDiffContents(request: ContentDiffRequest, onFinished: suspend (success: Boolean) -> Unit = {}) {
+        cs.launch {
+            withBackgroundProgress(project, message("background.decrypting")) {
+                for (content in SopsDiffContents.encryptedContents(request)) {
+                    val encryptedText = readAction { content.document.text }
+                    if (SopsDiffContents.isDecrypted(encryptedText)) {
+                        continue
+                    }
+
+                    var decryptedText: String? = null
+                    var errorMessage: String? = null
+                    SopsWrapper.decrypt(
+                        text = encryptedText,
+                        project = project,
+                        // SOPS picks the store from the file extension, so decrypting a content as
+                        // anything else returns it in another format. A binary store file, for
+                        // example, comes back wrapped in YAML.
+                        extension = content.highlightFile?.extension,
+                        workingDirectory = content.highlightFile?.parent?.path,
+                        onSuccess = { decryptedText = it },
+                        onError = { errorMessage = it }
+                    )
+                    val newDecryptedText = decryptedText
+                    if (newDecryptedText == null) {
+                        sendNotification(
+                            Notification(message = message("notification.diff.decrypt-failed", errorMessage.orEmpty())),
+                            project
+                        )
+                        onFinished(false)
+                        return@withBackgroundProgress
+                    }
+
+                    SopsDiffContents.remember(encryptedText, newDecryptedText)
+                    AppSettings.instance.recordHit()
+                }
+
+                onFinished(true)
             }
         }
     }

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/settings/AppSettings.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/settings/AppSettings.kt
@@ -28,6 +28,7 @@ class AppSettings : PersistentStateComponent<AppSettings> {
     var sopsPath: String? = null
     var sopsEnvironment: Map<String, String> = mapOf()
     var sopsEncryptOnChange = false
+    var sopsDecryptDiff = false
 
     override fun getState(): AppSettings {
         return this

--- a/src/main/kotlin/com/github/blarc/sops/intellij/plugin/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/blarc/sops/intellij/plugin/settings/AppSettingsConfigurable.kt
@@ -90,6 +90,12 @@ class AppSettingsConfigurable(val project: Project) : BoundConfigurable(message(
                     checkBox("")
                         .bindSelected(AppSettings.instance::sopsEncryptOnChange)
                 }
+                row {
+                    label(message("settings.decryptDiff"))
+                        .widthGroup("label")
+                    checkBox("")
+                        .bindSelected(AppSettings.instance::sopsDecryptDiff)
+                }.rowComment(message("settings.decryptDiff.comment"))
             }.align(AlignY.TOP)
         }.resizableRow()
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
             <li>Automatically decrypt the content of SOPS files</li>
             <li>Show encrypted content as preview</li>
             <li>On save, encrypt the contents, if the file has changed</li>
+            <li>Compare the decrypted contents of SOPS files in the comparison window</li>
         </ul>
         <h3>Usage</h3>
         <p>To get started, install the plugin and set path to SOPS executable in plugin's settings:
@@ -63,6 +64,13 @@
         />
         <postStartupActivity
                 implementation="com.github.blarc.sops.intellij.plugin.listeners.ApplicationStartupListener"
+        />
+
+        <diff.DiffTool
+                implementation="com.github.blarc.sops.intellij.plugin.diff.SopsSideBySideDiffTool"
+        />
+        <diff.DiffTool
+                implementation="com.github.blarc.sops.intellij.plugin.diff.SopsUnifiedDiffTool"
         />
 
     </extensions>

--- a/src/main/resources/messages/SopsBundle.properties
+++ b/src/main/resources/messages/SopsBundle.properties
@@ -22,3 +22,9 @@ actions.sure-take-me-there=Sure, take me there.
 notification.group.general.name=SOPS general
 notification.group.important.name=SOPS important
 settings.encryptOnChange=Encrypt on file changes
+settings.decryptDiff=Decrypt contents in the comparison window by default
+settings.decryptDiff.comment=The comparison window can always switch between the two from its toolbar.
+
+notification.diff.decrypt-failed=Could not decrypt the compared contents. {0}
+diff.decrypting=Decrypting the compared contents with SOPS...
+diff.action.show-decrypted=Show Decrypted Contents


### PR DESCRIPTION
Closes #91.

Comparing SOPS files — the same configuration of two environments, say — shows the encrypted contents, which cannot be read.

The comparison window now compares the decrypted contents of SOPS files. Its toolbar has a **Show Decrypted Contents** action that switches between the encrypted and the decrypted contents in the same window, and the setting `Decrypt contents in the comparison window by default` decides which of the two a window starts with. It is off by default, so nothing changes for existing users until they press the button. Contents that are not encrypted are shown as they are, so an encrypted file can also be compared with a plain one, and files that are not encrypted with SOPS are compared exactly as before.

A few notes for review:

* Each content is decrypted through the store of the file it comes from (`highlightFile`), for the same reason as in #95 — a binary store file decrypted as YAML comes back wrapped in `data: |`.
* Decrypting runs SOPS, which cannot be waited for while the window is being created. The window shows that it is decrypting and is reloaded once the decrypted contents are known, which is when they are handed to the viewer that would have shown the encrypted contents. That viewer keeps everything it can do with any other content.
* `SopsSideBySideDiffTool` and `SopsUnifiedDiffTool` take the place of the two viewers the window offers for text, each suppressing the one it replaces through `SuppressiveDiffTool` and reporting its name and tool type. The window therefore offers the same two viewers as for any other file, and switching between them goes through the platform. `DiffToolSubstitutor` would have been the shorter way to the same behaviour, but it is internal API and `verifyPlugin` fails on it.
* The decrypted contents are remembered by the encrypted contents they come from, and not by their documents, because a window that is reloaded compares the same contents in new documents. Only the last few are kept.
* Whether a content is encrypted is remembered until its document changes, because the viewers are asked about every content of every comparison.
* The decrypted contents are shown read only, because they are not backed by the files that are being compared and changes to them would be lost.
* A content that cannot be decrypted leaves its window showing the encrypted contents, with a notification, instead of being decrypted over and over again.

One thing this does not cover: the combined diff, which the commit dialog and the log can use, still shows the encrypted contents. Its `CombinedDiffContext` is not a `DiffContextEx`, so it cannot be reloaded once the decryption has finished.

### Testing

Tested in IntelliJ IDEA 2026.2 with binary store SOPS files: comparing two encrypted files from the project view and **Show Diff** on a modified encrypted file, in both viewers, switching back and forth between the encrypted and the decrypted contents, and with the setting both on and off. Also checked that a comparison of two plain files is untouched.

`./gradlew verifyPlugin` passes against all recommended IDEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
